### PR TITLE
Add irma-security plugin

### DIFF
--- a/examples/backends/irma-security/README.md
+++ b/examples/backends/irma-security/README.md
@@ -1,0 +1,15 @@
+# Nodejs security example
+
+This package is an example for how to use the `irma-security` plugin. The demo
+is supposed to be run with `nodejs` in the terminal. See the source of
+`index.js` for how we use the plugin.
+
+The demo shows how you can use a security token in the headers of your request
+to the IRMA server, or sign the payload with your private key.
+
+You can run this example by running these commands in this directory:
+
+```bash
+npm install
+npm start
+```

--- a/examples/backends/irma-security/index.js
+++ b/examples/backends/irma-security/index.js
@@ -1,0 +1,49 @@
+const IrmaCore = require('irma-core');
+const Console  = require('irma-console');
+const Server   = require('irma-server');
+const Security = require('irma-security');
+
+const irma = new IrmaCore({
+  debugging: true,
+
+  session: {
+    // Point this to your IRMA server:
+    url: 'http://localhost:8088',
+
+    // Define your disclosure request:
+    start: Security(
+      {
+        // Use security token in headers
+        method: 'token',
+        key: 'g8df7g9f7h6g7',
+
+        // // Sign the request using RS256
+        // method: 'publickey',
+        // key: 'dh897gh87fj76f9j6g',
+        // name: 'Sender name',
+        //
+        // // Sign the request using HS256
+        // method: 'hmac',
+        // key: '76fgh65fj6757gsg',
+        // name: 'Sender name'
+      },
+      {
+        body: {
+          "@context": "https://irma.app/ld/request/disclosure/v2",
+          "disclose": [
+            [
+              [ "pbdf.pbdf.email.email" ]
+            ]
+          ]
+        }
+      }
+    )
+  }
+});
+
+irma.use(Console);
+irma.use(Server);
+
+irma.start()
+.then(result => console.log("Successful disclosure! 🎉", result))
+.catch(error => console.error("Couldn't do what you asked 😢", error));

--- a/examples/backends/irma-security/package-lock.json
+++ b/examples/backends/irma-security/package-lock.json
@@ -1,0 +1,547 @@
+{
+  "name": "irma-backends-security-example",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "irma-console": {
+      "version": "file:../../../plugins/irma-console",
+      "requires": {
+        "prompt-sync": "^4.1.7",
+        "qrcode": "^1.4.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "dijkstrajs": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
+          "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "pngjs": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+          "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+        },
+        "prompt-sync": {
+          "version": "4.1.7",
+          "resolved": "https://registry.npmjs.org/prompt-sync/-/prompt-sync-4.1.7.tgz",
+          "integrity": "sha512-EPdLWdZCgNAxF8haGg1CKOL/F5KZiRtuqgoWc1EGefX+fX+5qsB8vI52+qzl1jgADO6AiLaIcioicxRgQEy5xA==",
+          "requires": {
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "qrcode": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.2.tgz",
+          "integrity": "sha512-eR6RgxFYPDFH+zFLTJKtoNP/RlsHANQb52AUmQ2bGDPMuUw7jJb0F+DNEgx7qQGIElrbFxWYMc0/B91zLZPF9Q==",
+          "requires": {
+            "dijkstrajs": "^1.0.1",
+            "isarray": "^2.0.1",
+            "pngjs": "^3.3.0",
+            "yargs": "^13.2.4"
+          }
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "irma-core": {
+      "version": "file:../../../irma-core"
+    },
+    "irma-security": {
+      "version": "file:../../../plugins/irma-security",
+      "requires": {
+        "jsonwebtoken": "^8.4.0"
+      },
+      "dependencies": {
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jsonwebtoken": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+          "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lodash.includes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+          "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+          "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.once": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "irma-server": {
+      "version": "file:../../../plugins/irma-server",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "eventsource": "^1.0.7",
+        "isomorphic-fetch": "^2.2.1"
+      },
+      "dependencies": {
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "eventsource": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+          "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+          "requires": {
+            "original": "^1.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "jsonwebtoken": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+          "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lodash.includes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+          "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+          "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.once": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "original": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+          "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+          "requires": {
+            "url-parse": "^1.4.3"
+          }
+        },
+        "querystringify": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+          "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+          "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "url-parse": {
+          "version": "1.4.7",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+          "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+          "requires": {
+            "querystringify": "^2.1.1",
+            "requires-port": "^1.0.0"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+          "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        }
+      }
+    }
+  }
+}

--- a/examples/backends/irma-security/package.json
+++ b/examples/backends/irma-security/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "irma-backends-security-example",
+  "version": "1.0.0",
+  "description": "An example on how to use the irma-security plugin",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node ./index.js"
+  },
+  "dependencies": {
+    "irma-console": "../../../plugins/irma-console",
+    "irma-core": "../../../irma-core",
+    "irma-server": "../../../plugins/irma-server",
+    "irma-security": "../../../plugins/irma-security"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/privacybydesign/irma-js-packages",
+    "directory": "examples/backends/irma-security"
+  }
+}

--- a/plugins/irma-security/README.md
+++ b/plugins/irma-security/README.md
@@ -1,7 +1,8 @@
 # IRMA security
 
 This plugin brings the JWT signing and token keys back to starting an IRMA
-session on the IRMA server. It is intended to be used with [`irma-server`](../irma-server).
+session on the IRMA server. It is intended to be used with the
+[`irma-server`](../irma-server) plugin.
 
 ## Usage
 
@@ -47,17 +48,19 @@ irma.start(/* parameters */);
 ## Options
 
 The first parameter to the method that `irma-security` exposes is an object that
-defines the `method` of security you with to use and a `key` and optional
+defines the `method` of security you wish to use and a `key` and optional
 `name`.
 
 The second parameter to the method is the object that you want to pass to the
 `session.start` option of `irma-server`. Only the `headers` and the `body`
 properties of this object will be touched by this method, the rest will be
-passed through. Note that `body` should be an object, not stringified JSON.
+passed through.
+
+Note that `body` should be an object, not stringified JSON.
 
 ### method
 
-Method has three valid values:
+The `method` property has three valid values:
 
 * `token` ⸺ use `key` as a security token in the headers of the request
 * `publickey` ⸺ sign the body of the request using RS256 and the supplied `key` and `name`

--- a/plugins/irma-security/README.md
+++ b/plugins/irma-security/README.md
@@ -1,0 +1,64 @@
+# IRMA security
+
+This plugin brings the JWT signing and token keys back to starting an IRMA
+session on the IRMA server. It is intended to be used with [`irma-server`](../irma-server).
+
+## Usage
+
+This plugin is not a plugin in the traditional sense. You don't use it with
+`irma.use(<plugin>)` but rather you use it to format your options:
+
+```javascript
+const IrmaCore = require('irma-core');
+const Server   = require('irma-server');
+const Security = require('irma-security');
+
+const irma = new IrmaCore({
+  session: {
+    // Point this to your IRMA server:
+    url: 'http://localhost:8088',
+
+    start: Security(
+      {
+        // Sign the request using RS256
+        method: 'publickey',
+        key: 'dh897gh8....7fj76f9j6g',
+        name: 'Sender name',
+      },
+      {
+        // Define your disclosure request:
+        body: {
+          "@context": "https://irma.app/ld/request/disclosure/v2",
+          "disclose": [
+            [
+              [ "pbdf.pbdf.email.email" ]
+            ]
+          ]
+        }
+      }
+    )
+  }
+});
+
+irma.use(Server);
+irma.start(/* parameters */);
+```
+
+## Options
+
+The first parameter to the method that `irma-security` exposes is an object that
+defines the `method` of security you with to use and a `key` and optional
+`name`.
+
+The second parameter to the method is the object that you want to pass to the
+`session.start` option of `irma-server`. Only the `headers` and the `body`
+properties of this object will be touched by this method, the rest will be
+passed through. Note that `body` should be an object, not stringified JSON.
+
+### method
+
+Method has three valid values:
+
+* `token` ⸺ use `key` as a security token in the headers of the request
+* `publickey` ⸺ sign the body of the request using RS256 and the supplied `key` and `name`
+* `hmac` ⸺ sign the body of the request using HS256 and the supplied `key` and `name`

--- a/plugins/irma-security/index.js
+++ b/plugins/irma-security/index.js
@@ -1,0 +1,52 @@
+const jsonwebtoken = require('jsonwebtoken');
+
+module.exports = function(settings, request) {
+  // Set headers right, depending on security method
+  request.headers = request.headers || {};
+
+  switch(settings.method) {
+    case 'token':
+      request.headers['Content-Type'] = 'application/json';
+      request.headers['Authorization'] = settings.key;
+      break;
+    case 'publickey':
+    case 'hmac':
+      request.headers['Content-Type'] = 'text/plain';
+      break;
+    default:
+      throw('Unsupported authentication method');
+  }
+
+  // Sign body
+  if ( settings.method == 'publickey' || settings.method == 'hmac' ) {
+    request.body = _signSessionRequest(request.body, settings.method, settings.key, settings.name);
+  } else {
+    request.body = JSON.stringify(request.body);
+  }
+
+  return request;
+}
+
+function _signSessionRequest(request, method, key, name) {
+  let type;
+  let rrequest;
+  if (request.type) {
+    type = request.type;
+    rrequest = { request };
+  } else if (request.request) {
+    type = request.request.type;
+    rrequest = request;
+  }
+
+  if (type !== 'disclosing' && type !== 'issuing' && type !== 'signing')
+    throw new Error('Not an IRMA session request');
+  if (method !== 'publickey' && method !== 'hmac')
+    throw new Error('Unsupported signing method');
+
+  const subjects = { disclosing: 'verification_request', issuing: 'issue_request', signing: 'signature_request' };
+  const fields = { disclosing: 'sprequest', issuing: 'iprequest', signing: 'absrequest' };
+  const algorithm = method === 'publickey' ? 'RS256' : 'HS256';
+  const jwtOptions = { algorithm, issuer: name, subject: subjects[type] };
+
+  return jsonwebtoken.sign({[ fields[type] ] : rrequest}, key, jwtOptions);
+}

--- a/plugins/irma-security/package.json
+++ b/plugins/irma-security/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "irma-security",
+  "version": "1.0.0",
+  "description": "A simple tool to allow JWT signing and key tokens in starting IRMA sessions",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "jsonwebtoken": "^8.4.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/privacybydesign/irma-js-packages",
+    "directory": "plugins/irma-security"
+  }
+}


### PR DESCRIPTION
# IRMA security

This plugin brings the JWT signing and token keys back to starting an IRMA
session on the IRMA server. It is intended to be used with [`irma-server`](https://github.com/privacybydesign/irma-js-packages/tree/master/plugins/irma-server).

## Usage

This plugin is not a plugin in the traditional sense. You don't use it with
`irma.use(<plugin>)` but rather you use it to format your options:

```javascript
const IrmaCore = require('irma-core');
const Server   = require('irma-server');
const Security = require('irma-security');

const irma = new IrmaCore({
  session: {
    // Point this to your IRMA server:
    url: 'http://localhost:8088',

    start: Security(
      {
        // Sign the request using RS256
        method: 'publickey',
        key: 'dh897gh8....7fj76f9j6g',
        name: 'Sender name',
      },
      {
        // Define your disclosure request:
        body: {
          "@context": "https://irma.app/ld/request/disclosure/v2",
          "disclose": [
            [
              [ "pbdf.pbdf.email.email" ]
            ]
          ]
        }
      }
    )
  }
});

irma.use(Server);
irma.start(/* parameters */);
```

## Options

The first parameter to the method that `irma-security` exposes is an object that
defines the `method` of security you with to use and a `key` and optional
`name`.

The second parameter to the method is the object that you want to pass to the
`session.start` option of `irma-server`. Only the `headers` and the `body`
properties of this object will be touched by this method, the rest will be
passed through. Note that `body` should be an object, not stringified JSON.

### method

Method has three valid values:

* `token` ⸺ use `key` as a security token in the headers of the request
* `publickey` ⸺ sign the body of the request using RS256 and the supplied `key` and `name`
* `hmac` ⸺ sign the body of the request using HS256 and the supplied `key` and `name`