### PR TITLE
Auto-restart timed out sessions

### DIFF
--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -10,6 +10,8 @@ module.exports = class IrmaCore {
 
     this._stateMachine = new StateMachine(this._options.debugging);
     this._stateMachine.addStateChangeListener((s) => this._stateChangeListener(s));
+
+    this._addVisibilityListener();
   }
 
   use(mod) {
@@ -48,6 +50,16 @@ module.exports = class IrmaCore {
           this._stateMachine.transition('showQRCode', payload);
         break;
     }
+  }
+
+  _addVisibilityListener() {
+    if ( typeof document === 'undefined' || !document.addEventListener ) return;
+
+    document.addEventListener('visibilitychange', () => {
+      if ( this._stateMachine.currentState() != 'TimedOut' ) return;
+      if ( document.hidden ) return;
+      this._stateMachine.transition('restart');
+    });
   }
 
 }

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -53,13 +53,20 @@ module.exports = class IrmaCore {
   }
 
   _addVisibilityListener() {
-    if ( typeof document === 'undefined' || !document.addEventListener ) return;
+    if ( typeof document !== 'undefined' && document.addEventListener )
+      document.addEventListener('visibilitychange', () => {
+        if ( this._stateMachine.currentState() != 'TimedOut' ) return;
+        if ( document.hidden ) return;
+        console.log("🖥 Visibility changed to visible!");
+        this._stateMachine.transition('restart');
+      });
 
-    document.addEventListener('visibilitychange', () => {
-      if ( this._stateMachine.currentState() != 'TimedOut' ) return;
-      if ( document.hidden ) return;
-      this._stateMachine.transition('restart');
-    });
+    if ( typeof window !== 'undefined' && window.addEventListener )
+      window.addEventListener('focus', () => {
+        if ( this._stateMachine.currentState() != 'TimedOut' ) return;
+        console.log("🖥 Window gained focus!");
+        this._stateMachine.transition('restart');
+      });
   }
 
 }

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -55,16 +55,15 @@ module.exports = class IrmaCore {
   _addVisibilityListener() {
     if ( typeof document !== 'undefined' && document.addEventListener )
       document.addEventListener('visibilitychange', () => {
-        if ( this._stateMachine.currentState() != 'TimedOut' ) return;
-        if ( document.hidden ) return;
-        console.log("🖥 Visibility changed to visible!");
+        if ( this._stateMachine.currentState() != 'TimedOut' || document.hidden ) return;
+        if ( this._options.debugging ) console.log('🖥 Restarting because document became visible');
         this._stateMachine.transition('restart');
       });
 
     if ( typeof window !== 'undefined' && window.addEventListener )
       window.addEventListener('focus', () => {
         if ( this._stateMachine.currentState() != 'TimedOut' ) return;
-        console.log("🖥 Window gained focus!");
+        if ( this._options.debugging ) console.log('🖥 Restarting because window regained focus');
         this._stateMachine.transition('restart');
       });
   }

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -8,6 +8,10 @@ module.exports = class StateMachine {
     this._listeners = [];
   }
 
+  currentState() {
+    return this._state;
+  }
+
   addStateChangeListener(func) {
     this._listeners.push(func);
   }


### PR DESCRIPTION
Auto-restart timed out sessions when our browser tab regains focus.

Just a nicety to be friendly to the user. It's a progressive enhancement, and it doesn't work everywhere every time, but it works for most cases in semi-modern browsers.