### PR TITLE
Deprecate start method parameters

### DIFF
--- a/examples/browser/irma-console/index.js
+++ b/examples/browser/irma-console/index.js
@@ -10,6 +10,6 @@ const irma = new IrmaCore({
 irma.use(Console);
 irma.use(Dummy);
 
-irma.start('server_url', { request: 'content' })
+irma.start()
 .then(result => console.log("Successful disclosure! 🎉", result))
 .catch(error => console.error("Couldn't do what you asked 😢", error));

--- a/examples/browser/irma-popup/index.js
+++ b/examples/browser/irma-popup/index.js
@@ -22,7 +22,7 @@ document.getElementById('start-button').addEventListener('click', () => {
   irma.use(Popup);
   irma.use(Dummy);
 
-  irma.start('server_url', { request: 'content' })
+  irma.start()
   .then(result => console.log("Successful disclosure! 🎉", result))
   .catch(error => console.error("Couldn't do what you asked 😢", error));
 

--- a/examples/browser/irma-web/index.js
+++ b/examples/browser/irma-web/index.js
@@ -1,8 +1,8 @@
 require('irma-css/dist/irma.css');
 
-const IrmaCore   = require('irma-core');
-const IrmaWeb    = require('irma-web');
-const Dummy      = require('irma-dummy');
+const IrmaCore = require('irma-core');
+const IrmaWeb  = require('irma-web');
+const Dummy    = require('irma-dummy');
 
 const irma = new IrmaCore({
   debugging: true,
@@ -17,6 +17,6 @@ const irma = new IrmaCore({
 irma.use(IrmaWeb);
 irma.use(Dummy);
 
-irma.start('server_url', { request: 'content' })
+irma.start()
 .then(result => console.log("Successful disclosure! 🎉", result))
 .catch(error => console.error("Couldn't do what you asked 😢", error));

--- a/examples/node/irma-console/index.js
+++ b/examples/node/irma-console/index.js
@@ -10,6 +10,6 @@ const irma = new IrmaCore({
 irma.use(Console);
 irma.use(Dummy);
 
-irma.start('server_url', { request: 'content' })
+irma.start()
 .then(result => console.log("Successful disclosure! 🎉", result))
 .catch(error => console.error("Couldn't do what you asked 😢", error));

--- a/irma-core/README.md
+++ b/irma-core/README.md
@@ -10,7 +10,7 @@ const irma     = new IrmaCore(/* options */);
 irma.use(/* Plugin A */);
 irma.use(/* Plugin B */);
 
-irma.start(/* parameters */);
+irma.start();
 ```
 
 You can pass an options object to the constructor, which will be passed on to
@@ -25,11 +25,11 @@ const irma = new IrmaCore({
 ```
 
 The `start` method starts the state machine and returns a Promise. Whatever
-parameters you pass to the `start` method get passed to the `start` method of the
-plugins too.
+parameters you pass to the `start` method get passed to the `start` method of
+the plugins too, but no plugins currently make use of that.
 
 ```javascript
-irma.start(/* parameters */)
+irma.start()
     .then(result => console.log("Successful disclosure! 🎉", result))
     .catch(error => console.error("Couldn't do what you asked 😢", error));
 ```

--- a/plugins/irma-console/README.md
+++ b/plugins/irma-console/README.md
@@ -14,5 +14,5 @@ const Console  = require('irma-console');
 
 const irma = new IrmaCore(/* options */);
 irma.use(Console);
-irma.start(/* parameters */);
+irma.start();
 ```

--- a/plugins/irma-dummy/README.md
+++ b/plugins/irma-dummy/README.md
@@ -19,7 +19,7 @@ const irma = new IrmaCore({
 });
 
 irma.use(Dummy);
-irma.start(/* parameters */);
+irma.start();
 ```
 
 ## Options

--- a/plugins/irma-dummy/index.js
+++ b/plugins/irma-dummy/index.js
@@ -19,9 +19,9 @@ module.exports = class IrmaDummy {
     }
   }
 
-  start(server, request) {
+  start() {
     if ( this._options.debugging )
-      console.log(`🧙🏼‍♂️ Fake-requesting server '${server}' for request:\n`, request);
+      console.log(`🧙🏼‍♂️ Initializing fake IRMA flow`);
 
     switch(this._options.dummy) {
       case 'browser unsupported':

--- a/plugins/irma-popup/README.md
+++ b/plugins/irma-popup/README.md
@@ -19,7 +19,7 @@ const Popup    = require('irma-popup');
 
 const irma = new IrmaCore(/* options */);
 irma.use(Popup);
-irma.start(/* parameters */);
+irma.start();
 ```
 
 ## Options

--- a/plugins/irma-server/README.md
+++ b/plugins/irma-server/README.md
@@ -33,7 +33,7 @@ const irma = new IrmaCore({
 });
 
 irma.use(Server);
-irma.start(/* parameters */);
+irma.start();
 ```
 
 ## Options

--- a/plugins/irma-web/README.md
+++ b/plugins/irma-web/README.md
@@ -23,7 +23,7 @@ const irma = new IrmaCore({
 });
 
 irma.use(Web);
-irma.start(/* parameters */);
+irma.start();
 ```
 
 ## Options


### PR DESCRIPTION
All parameters for the IRMA flow are now passed to the constructor of `irma-core`. Using start method parameters is no longer needed. Some plugin may wish to use it at some point, but for now lets remove it from the documentation and examples.