### PR TITLE
Introduced Aborted state

### DIFF
--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -41,6 +41,7 @@ module.exports = class IrmaCore {
         if ( this._resolve ) this._resolve(payload);
         break;
       case 'BrowserNotSupported':
+      case 'Aborted':
         if ( this._reject ) this._reject(payload);
         break;
       case 'MediumContemplation':

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -12,6 +12,10 @@ module.exports = class StateMachine {
     return this._state;
   }
 
+  isEndState() {
+    return Object.keys(transitions[this._state]).length === 0;
+  }
+
   addStateChangeListener(func) {
     this._listeners.push(func);
   }

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -18,18 +18,21 @@ module.exports = {
 
   Loading: {
     loaded:         'MediumContemplation',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
   MediumContemplation: {
     showQRCode:     'ShowingQRCode',
     showIrmaButton: 'ShowingIrmaButton',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
   ShowingQRCode: {
     appConnected:   'ContinueOn2ndDevice',
     timeout:        'TimedOut',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
@@ -38,12 +41,14 @@ module.exports = {
     cancel:         'Cancelled',
     restart:        'Loading',
     timeout:        'TimedOut',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
   ShowingIrmaButton: {
     chooseQR:       'ShowingQRCodeInstead',
     appConnected:   'ContinueInIrmaApp',
+    abort:          'Aborted',
     fail:           'Error',
 
     succeed:        'Success',   // We sometimes miss the appConnected transition
@@ -55,6 +60,7 @@ module.exports = {
     appConnected:   'ContinueOn2ndDevice',
     restart:        'Loading',
     timeout:        'TimedOut',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
@@ -63,23 +69,28 @@ module.exports = {
     cancel:         'Cancelled',
     restart:        'Loading',
     timeout:        'TimedOut',
+    abort:          'Aborted',
     fail:           'Error'
   },
 
   Cancelled: {
+    abort:          'Aborted',
     restart:        'Loading'
   },
 
   TimedOut: {
+    abort:          'Aborted',
     restart:        'Loading'
   },
 
   Error: {
+    abort:          'Aborted',
     restart:        'Loading'
   },
 
   // End states
   BrowserNotSupported: {},
-  Success: {}
+  Success: {},
+  Aborted: {}
 
 }

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -18,21 +18,21 @@ module.exports = {
 
   Loading: {
     loaded:         'MediumContemplation',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
   MediumContemplation: {
     showQRCode:     'ShowingQRCode',
     showIrmaButton: 'ShowingIrmaButton',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
   ShowingQRCode: {
     appConnected:   'ContinueOn2ndDevice',
     timeout:        'TimedOut',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
@@ -41,14 +41,14 @@ module.exports = {
     cancel:         'Cancelled',
     restart:        'Loading',
     timeout:        'TimedOut',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
   ShowingIrmaButton: {
     chooseQR:       'ShowingQRCodeInstead',
     appConnected:   'ContinueInIrmaApp',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error',
 
     succeed:        'Success',   // We sometimes miss the appConnected transition
@@ -60,7 +60,7 @@ module.exports = {
     appConnected:   'ContinueOn2ndDevice',
     restart:        'Loading',
     timeout:        'TimedOut',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
@@ -69,28 +69,28 @@ module.exports = {
     cancel:         'Cancelled',
     restart:        'Loading',
     timeout:        'TimedOut',
-    abort:          'Aborted',
+    abort:          'Ended',
     fail:           'Error'
   },
 
   Cancelled: {
-    abort:          'Aborted',
+    abort:          'Ended',
     restart:        'Loading'
   },
 
   TimedOut: {
-    abort:          'Aborted',
+    abort:          'Ended',
     restart:        'Loading'
   },
 
   Error: {
-    abort:          'Aborted',
+    abort:          'Ended',
     restart:        'Loading'
   },
 
   // End states
   BrowserNotSupported: {},
   Success: {},
-  Aborted: {}
+  Ended: {}
 
 }

--- a/plugins/irma-console/irma-console.js
+++ b/plugins/irma-console/irma-console.js
@@ -26,6 +26,7 @@ module.exports = (askRetry) => {
     _askRetry(message) {
       if ( askRetry(message) )
         this._stateMachine.transition('restart');
+      this._stateMachine.transition('abort', 'Aborted by user');
     }
 
     _renderQRcode(payload) {

--- a/plugins/irma-console/irma-console.js
+++ b/plugins/irma-console/irma-console.js
@@ -25,7 +25,7 @@ module.exports = (askRetry) => {
 
     _askRetry(message) {
       if ( askRetry(message) )
-        this._stateMachine.transition('restart');
+        return this._stateMachine.transition('restart');
       this._stateMachine.transition('abort', 'Aborted by user');
     }
 

--- a/plugins/irma-dummy/index.js
+++ b/plugins/irma-dummy/index.js
@@ -33,6 +33,10 @@ module.exports = class IrmaDummy {
 
   _startNewSession() {
     setTimeout(() => {
+      // Stop when already being in end state
+      if (this._stateMachine.isEndState())
+        return;
+
       switch(this._options.dummy) {
         case 'connection error':
           return this._stateMachine.transition('fail');
@@ -44,6 +48,10 @@ module.exports = class IrmaDummy {
 
   _waitForScanning() {
     setTimeout(() => {
+      // Stop when already being in end state
+      if (this._stateMachine.isEndState())
+        return;
+
       switch(this._options.dummy) {
         case 'timeout':
           return this._stateMachine.transition('timeout');
@@ -55,6 +63,10 @@ module.exports = class IrmaDummy {
 
   _waitForUserAction() {
     setTimeout(() => {
+      // Stop when already being in end state
+      if (this._stateMachine.isEndState())
+        return;
+
       switch(this._options.dummy) {
         case 'cancel':
           return this._stateMachine.transition('cancel');

--- a/plugins/irma-popup/index.js
+++ b/plugins/irma-popup/index.js
@@ -7,7 +7,8 @@ module.exports = class IrmaPopup {
     this._stateMachine = stateMachine;
 
     this._dom = new DOMManipulations(options.element, () => {
-      stateMachine.transition('cancel');
+      if (!stateMachine.isEndState())
+        stateMachine.transition('abort', 'Popup closed');
     });
 
     this._irmaWeb = new IrmaWeb({
@@ -26,6 +27,8 @@ module.exports = class IrmaPopup {
     switch(newState) {
       case 'Loading':
         return this._dom.openPopup();
+      case 'Aborted':
+        return this._dom.closePopup();
       case 'Success':
       case 'BrowserNotSupported':
         // Delay closing pop-up so that the user can see the animation

--- a/plugins/irma-popup/index.js
+++ b/plugins/irma-popup/index.js
@@ -27,7 +27,7 @@ module.exports = class IrmaPopup {
     switch(newState) {
       case 'Loading':
         return this._dom.openPopup();
-      case 'Aborted':
+      case 'Ended':
         return this._dom.closePopup();
       case 'Success':
       case 'BrowserNotSupported':

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -20,7 +20,7 @@ module.exports = class IrmaServer {
       case 'Cancelled':
       case 'TimedOut':
       case 'Error':
-      case 'Aborted':
+      case 'Ended':
         return this._serverState.close();
     }
   }

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -20,6 +20,7 @@ module.exports = class IrmaServer {
       case 'Cancelled':
       case 'TimedOut':
       case 'Error':
+      case 'Aborted':
         return this._serverState.close();
     }
   }

--- a/plugins/irma-web/dom-manipulations.js
+++ b/plugins/irma-web/dom-manipulations.js
@@ -12,7 +12,7 @@ module.exports = class DOMManipulations {
   }
 
   renderState(state) {
-    if ( state == 'Aborted' ) return;
+    if ( state == 'Ended' ) return;
     let newPartial = this._stateToPartialMapping()[state];
     if (!newPartial) throw new Error(`I don't know how to render '${state}'`);
     this._renderPartial(newPartial);

--- a/plugins/irma-web/dom-manipulations.js
+++ b/plugins/irma-web/dom-manipulations.js
@@ -56,6 +56,7 @@ module.exports = class DOMManipulations {
       TimedOut:             this._stateTimedOut,
       Error:                this._stateError,
       BrowserNotSupported:  this._stateBrowserNotSupported,
+      Aborted:              this._stateAborted,
       Success:              this._stateSuccess
     };
   }
@@ -169,6 +170,14 @@ module.exports = class DOMManipulations {
       <!-- State: BrowserNotSupported -->
       <div class="irma-web-forbidden-animation"></div>
       <p>${this._translations.browser}</p>
+    `;
+  }
+
+  _stateAborted() {
+    return `
+      <!-- State: Error -->
+      <div class="irma-web-forbidden-animation"></div>
+      <p>${this._translations.error}</p>
     `;
   }
 

--- a/plugins/irma-web/dom-manipulations.js
+++ b/plugins/irma-web/dom-manipulations.js
@@ -12,6 +12,7 @@ module.exports = class DOMManipulations {
   }
 
   renderState(state) {
+    if ( state == 'Aborted' ) return;
     let newPartial = this._stateToPartialMapping()[state];
     if (!newPartial) throw new Error(`I don't know how to render '${state}'`);
     this._renderPartial(newPartial);
@@ -56,7 +57,6 @@ module.exports = class DOMManipulations {
       TimedOut:             this._stateTimedOut,
       Error:                this._stateError,
       BrowserNotSupported:  this._stateBrowserNotSupported,
-      Aborted:              this._stateAborted,
       Success:              this._stateSuccess
     };
   }
@@ -170,14 +170,6 @@ module.exports = class DOMManipulations {
       <!-- State: BrowserNotSupported -->
       <div class="irma-web-forbidden-animation"></div>
       <p>${this._translations.browser}</p>
-    `;
-  }
-
-  _stateAborted() {
-    return `
-      <!-- State: Error -->
-      <div class="irma-web-forbidden-animation"></div>
-      <p>${this._translations.error}</p>
     `;
   }
 


### PR DESCRIPTION
Introduced a separate aborted state. When a popup is closed, the same instance cannot be started again. This means the promise that `irmaCore.start()` returns has to resolve or reject (depending on the case). I think the most neat solution for this is to make a separate state for this scenario such that `irma-core` can detect when the state gets in a unrecoverable state.