### PR TITLE
Fixes for some bugs

### DIFF
--- a/plugins/irma-dummy/index.js
+++ b/plugins/irma-dummy/index.js
@@ -35,7 +35,7 @@ module.exports = class IrmaDummy {
     setTimeout(() => {
       switch(this._options.dummy) {
         case 'connection error':
-          return this._stateMachine.transition('error');
+          return this._stateMachine.transition('fail');
         default:
           return this._stateMachine.transition('loaded', this._options.qrPayload);
       }

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -16,6 +16,11 @@ module.exports = class IrmaServer {
         return this._startNewSession();
       case 'MediumContemplation':
         return this._startWatchingServerState(payload);
+      case 'Success':
+      case 'Cancelled':
+      case 'TimedOut':
+      case 'Error':
+        return this._serverState.close();
     }
   }
 
@@ -50,9 +55,6 @@ module.exports = class IrmaServer {
   _serverStateChange(newState) {
     if ( newState == 'CONNECTED' )
       return this._stateMachine.transition('appConnected');
-
-    // All other states lead to a full session reload, so stop listening
-    this._serverState.close();
 
     switch(newState) {
       case 'DONE':

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -43,13 +43,20 @@ module.exports = class IrmaServer {
     this._serverState = new ServerState(payload.u, this._options.state);
 
     try {
-      this._serverState.observe(s => this._serverStateChange(s));
+      this._serverState.observe(s => this._serverStateChange(s), e => this._serverHandleError(e));
     } catch (error) {
       if ( this._options.debugging )
-        console.error("Error while observing server state: ", error);
+        console.error("Observing server state could not be started: ", error);
 
       this._stateMachine.transition('fail');
     }
+  }
+
+  _serverHandleError(error) {
+    if ( this._options.debugging )
+      console.error("Error while observing server state: ", error);
+
+    this._stateMachine.transition('fail');
   }
 
   _serverStateChange(newState) {

--- a/plugins/irma-server/index.js
+++ b/plugins/irma-server/index.js
@@ -35,7 +35,7 @@ module.exports = class IrmaServer {
       if ( this._options.debugging )
         console.error("Error starting a new session on the server:", error);
 
-      this._stateMachine.transition('error');
+      this._stateMachine.transition('fail');
     })
   }
 
@@ -48,7 +48,7 @@ module.exports = class IrmaServer {
       if ( this._options.debugging )
         console.error("Error while observing server state: ", error);
 
-      this._stateMachine.transition('error');
+      this._stateMachine.transition('fail');
     }
   }
 
@@ -83,7 +83,7 @@ module.exports = class IrmaServer {
       if ( this._options.debugging )
         console.error("Error fetching session result from the server:", error);
 
-      this._stateMachine.transition('error');
+      this._stateMachine.transition('fail');
     });
   }
 

--- a/plugins/irma-server/server-state.js
+++ b/plugins/irma-server/server-state.js
@@ -10,8 +10,9 @@ module.exports = class ServerState {
     this._options.url = url;
   }
 
-  observe(stateChangeCallback) {
+  observe(stateChangeCallback, errorCallback) {
     this._stateChangeCallback = stateChangeCallback;
+    this._errorCallback = errorCallback;
 
     if ( this._eventSource && this._options.serverSentEvents )
       return this._startSSE();
@@ -103,7 +104,7 @@ module.exports = class ServerState {
     } catch(error) {
       if ( this._options.debugging )
         console.error("🌎 Error thrown while polling: ", error);
-      throw(error);
+      this._errorCallback(error);
     }
 
     if ( this._options.debugging )


### PR DESCRIPTION
Fixes:
- Polling is not stopped when doing a forced state change (i.e. cancellation/aborting of popup by user)
- Some `fail` transition were wrongly labeled as `error` transitions
- Server state throws an error in case of network issues. However, this function is async, so the error was not caught. I added a error handler for this error.