### PR TITLE
Re-design of state machine API to prevent that developers introduce race conditions

### DIFF
--- a/examples/browser/irma-console/package.json
+++ b/examples/browser/irma-console/package.json
@@ -4,7 +4,7 @@
   "description": "An example on how to use the irma-console package",
   "main": "index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack --mode development"
   },
   "license": "MIT",
   "dependencies": {

--- a/examples/browser/irma-popup/package.json
+++ b/examples/browser/irma-popup/package.json
@@ -4,7 +4,7 @@
   "description": "An example on how to use the irma-popup package",
   "main": "index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack --mode development"
   },
   "license": "MIT",
   "dependencies": {

--- a/examples/browser/irma-web/index.js
+++ b/examples/browser/irma-web/index.js
@@ -6,6 +6,7 @@ const Dummy    = require('@privacybydesign/irma-dummy');
 
 const irma = new IrmaCore({
   debugging: true,
+  dummy: 'happy path',
   element:   '#irma-web-form',
   language:  'en',
   translations: {

--- a/examples/browser/irma-web/package.json
+++ b/examples/browser/irma-web/package.json
@@ -4,7 +4,7 @@
   "description": "An example on how to use the irma-web package",
   "main": "index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack --mode development"
   },
   "license": "MIT",
   "dependencies": {

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -30,12 +30,15 @@ module.exports = class IrmaCore {
   }
 
   abort() {
-    if (this._stateMachine.currentState() != 'Uninitialized' && !this._stateMachine.isEndState()) {
-      if (this._options.debugging) console.log('🖥 Manually aborting session instance');
-      this._stateMachine.transition('abort');
-    } else {
-      if (this._options.debugging) console.log('🖥 Manual abort is not necessary');
-    }
+    return this._stateMachine.selectTransition(({state, inEndState}) => {
+      if (state != 'Uninitialized' && !inEndState) {
+        if (this._options.debugging) console.log('🖥 Manually aborting session instance');
+        return {transition: 'abort'};
+      } else {
+        if (this._options.debugging) console.log('🖥 Manual abort is not necessary');
+        return false;
+      }
+    });
   }
 
   _stateChangeListener(state) {

--- a/irma-core/index.js
+++ b/irma-core/index.js
@@ -18,6 +18,8 @@ module.exports = class IrmaCore {
   }
 
   start(...input) {
+    if (this._resolve) throw new Error('The irma-core instance has already been started');
+
     if (this._options.debugging)
       console.log("Starting session with options:", this._options);
 
@@ -33,7 +35,7 @@ module.exports = class IrmaCore {
     return this._stateMachine.selectTransition(({state, inEndState}) => {
       if (state != 'Uninitialized' && !inEndState) {
         if (this._options.debugging) console.log('🖥 Manually aborting session instance');
-        return {transition: 'abort'};
+        return { transition: 'abort' };
       } else {
         if (this._options.debugging) console.log('🖥 Manual abort is not necessary');
         return false;

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -11,70 +11,104 @@ module.exports = class StateMachine {
     this._disabledTransitions = [];
   }
 
+  /* Deprecated
   currentState() {
     return this._state;
-  }
+  } *
 
+  /* Deprecated
   isEndState() {
     return this._inEndState;
-  }
+  } */
 
+  /* Deprecated
   isValidTransition(transition) {
     if (this._inEndState || this._disabledTransitions.includes(transition))
       return false;
     return transitions[this._state][transition] != undefined;
-  }
+  } */
 
   addStateChangeListener(func) {
     this._listeners.push(func);
   }
 
+  // TODO: Add docs
   transition(transition, payload) {
-    this._performTransition(transition, false, payload)
+    return this._performTransition({transition, payload});
   }
 
+  // TODO: Add docs
   finalTransition(transition, payload) {
-    this._performTransition(transition, true, payload);
+    return this._performTransition({transition, payload, isFinal: true});
   }
 
-  _performTransition(transition, isFinal, payload) {
-    if (this._inTransition) {
-      // This can only happen when a transition is initiated within the callback of a state change listener.
-      throw new Error('Cannot perform a new transition within a state change');
-    }
-    this._inTransition = true;
-
-    try {
-      const oldState = this._state;
-      if (this._inEndState)
-        throw new Error(`State machine is in an end state. No transitions are allowed from ${oldState}.`);
-      this._state = this._getNewState(transition, isFinal);
-
-      if (this._debugging)
-        console.debug(`🎰 State change: '${oldState}' → '${this._state}' (because of '${transition}')`);
-
-      // State is also an end state when no transitions are available from that state. We exclude the
-      // abort transition since abort is only intended to turn a non end state into an end state.
-      let isEnabled = t => !this._disabledTransitions.includes(t) && t != 'abort';
-      this._inEndState = isFinal || Object.keys(transitions[this._state]).filter(isEnabled).length == 0;
-
-      if (transition === 'initialize')
-        this._disabledTransitions = payload.canRestart ? [] : ['restart'];
-
-      if (transition === 'restart') {
-        payload = {...payload, canRestart: true};
+  /**
+   * Initiate a transition based on the current state of the state machine. As parameter a
+   * callback function should be specified which should return the desired transition.
+   * The callback function receives information about the current state as parameter.
+   * In case you conclude you don't want to do a transition after all, you can return false.
+   * In case you decide to do a transition, you return the following:
+   * {
+   *   transition: 'someTransition', // Required
+   *   isFinal: false,               // Optional; default value is false
+   *   payload: 'some'               // Optional; default value is undefined
+   * }
+   * @param selectCallback: ({state, validTransitions, inEndState}) => {...}
+   * @returns Promise<void>, Promise is rejected when an invalid transition is chosen.
+   */
+  selectTransition(selectCallback) {
+    // Don't use promise chaining to prevent race-conditions.
+    return new Promise((resolve, reject) => {
+      let selected = selectCallback({
+        state: this._state,
+        validTransitions: this._getValidTransitions(),
+        inEndState: this._inEndState,
+      });
+      if (!selected) {
+        return resolve();
       }
+      try {
+        this._performTransition(selected);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
 
-      this._listeners.forEach(func => func({
-        newState: this._state,
-        oldState: oldState,
-        transition: transition,
-        isFinal: this._inEndState,
-        payload: payload
-      }));
-    } finally {
-      this._inTransition = false;
+  _getValidTransitions() {
+    let isEnabled = t => !this._disabledTransitions.includes(t);
+    return Object.keys(transitions[this._state]).filter(isEnabled);
+  }
+
+  // This function is non-async by design, to prevent race conditions when two transitions are started simultaneously.
+  _performTransition({transition, isFinal, payload}) {
+    const oldState = this._state;
+    if (this._inEndState)
+      throw new Error(`State machine is in an end state. No transitions are allowed from ${oldState}.`);
+    this._state = this._getNewState(transition, isFinal);
+
+    if (this._debugging)
+      console.debug(`🎰 State change: '${oldState}' → '${this._state}' (because of '${transition}')`);
+
+    // State is also an end state when no transitions are available from that state. We exclude the
+    // abort transition since abort is only intended to turn a non end state into an end state.
+    this._inEndState = isFinal || this._getValidTransitions().filter(t => t != 'abort').length == 0;
+
+    if (transition === 'initialize')
+      this._disabledTransitions = payload.canRestart ? [] : ['restart'];
+
+    if (transition === 'restart') {
+      payload = {...payload, canRestart: true};
     }
+
+    this._listeners.forEach(func => func({
+      newState: this._state,
+      oldState: oldState,
+      transition: transition,
+      isFinal: this._inEndState,
+      payload: payload
+    }));
   }
 
   _getNewState(transition, isFinal) {

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -98,10 +98,6 @@ module.exports = class StateMachine {
     if (transition === 'initialize')
       this._disabledTransitions = payload.canRestart ? [] : ['restart'];
 
-    if (transition === 'restart') {
-      payload = {...payload, canRestart: true};
-    }
-
     this._listeners.forEach(func => func({
       newState: this._state,
       oldState: oldState,

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -23,7 +23,7 @@ module.exports = class StateMachine {
    */
   transition(transition, payload) {
     console.warn('The \'transition\' function of the irma-core state machine is deprecated. Please use \'selectTransition\'.');
-    return this._performTransition({transition, payload});
+    return this.selectTransition(() => ({transition, payload}));
   }
 
   /**
@@ -37,7 +37,7 @@ module.exports = class StateMachine {
    */
   finalTransition(transition, payload) {
     console.warn('The \'finalTransition\' function of the irma-core state machine is deprecated. Please use \'selectTransition\'.');
-    return this._performTransition({transition, payload, isFinal: true});
+    return this.selectTransition(() => ({transition, payload, isFinal: true}));
   }
 
   /**

--- a/irma-core/state-machine.js
+++ b/irma-core/state-machine.js
@@ -97,11 +97,11 @@ module.exports = class StateMachine {
       this._disabledTransitions = payload.canRestart ? [] : ['restart'];
 
     this._listeners.forEach(func => func({
-      newState: this._state,
-      oldState: oldState,
+      newState:   this._state,
+      oldState:   oldState,
       transition: transition,
-      isFinal: this._inEndState,
-      payload: payload
+      isFinal:    this._inEndState,
+      payload:    payload
     }));
   }
 

--- a/irma-core/state-transitions.js
+++ b/irma-core/state-transitions.js
@@ -14,7 +14,6 @@ module.exports = {
   Uninitialized: {
     initialize:     'Loading',              // Expected payload: {canRestart: true/false}
     browserError:   'BrowserNotSupported',  // Expected payload: undefined
-    fail:           'Error'                 // Expected payload: error object
   },
 
   Loading: {

--- a/irma-frontend/package.json
+++ b/irma-frontend/package.json
@@ -4,6 +4,7 @@
   "description": "A simplified package of irma-frontend modules to get started easily",
   "main": "dist/irma.js",
   "scripts": {
+    "dev": "webpack --mode development --watch",
     "build": "webpack --mode production",
     "release": "npm run build"
   },

--- a/plugins/irma-client/state-client.js
+++ b/plugins/irma-client/state-client.js
@@ -13,7 +13,7 @@ module.exports = class IrmaStateClient {
   stateChange({newState, transition, payload}) {
     switch(newState) {
       case 'Loading':
-        this._canRestart = payload.canRestart;
+        this._canRestart = transition == 'restart' || payload.canRestart;
         break;
       case 'CheckingUserAgent':
         if (transition == 'loaded') {

--- a/plugins/irma-client/state-client.js
+++ b/plugins/irma-client/state-client.js
@@ -26,16 +26,9 @@ module.exports = class IrmaStateClient {
         this._determineFlow();
         break;
       case 'PreparingQRCode':
-        return this._updatePairingState(true)
-          .then(() => this._stateMachine.transition('showQRCode', {
-            qr: JSON.stringify(this._mappings.sessionPtr),
-            showBackButton: transition == 'chooseQR',
-          }));
+        return this._updatePairingState(transition, true);
       case 'PreparingIrmaButton':
-        return this._updatePairingState(false)
-          .then(() => this._stateMachine.transition('showIrmaButton', {
-            mobile: this._getMobileUrl(this._mappings.sessionPtr),
-          }));
+        return this._updatePairingState(transition, false);
       case 'ShowingQRCode':
       case 'ShowingIrmaButton':
         this._startWatchingServerState(payload);
@@ -44,12 +37,11 @@ module.exports = class IrmaStateClient {
         if (this._frontendOptions.pairingCode === payload.enteredPairingCode) {
           this._pairingCompleted();
         } else {
-          setTimeout(() => {
-            // The state might have changed in Cancelled, TimedOut or Error while
-            // waiting, so we have to check the validity of the transition.
-            if (this._stateMachine.isValidTransition('pairingRejected'))
-              this._stateMachine.transition('pairingRejected', payload);
-          }, this._options.state.pairing.minCheckingDelay);
+          setTimeout(() => this._stateMachine.selectTransition(({validTransitions}) =>
+            validTransitions.includes('pairingRejected')
+              ? { transition: 'pairingRejected', payload: payload }
+              : false
+          ), this._options.state.pairing.minCheckingDelay);
         }
         break;
       case 'PreparingResult':
@@ -72,15 +64,14 @@ module.exports = class IrmaStateClient {
   }
 
   _startWatchingServerState() {
-    // A new transition cannot be started within stateChange, so add call to javascript event loop.
-    Promise.resolve().then(() =>
+    try {
       this._statusListener.observe(s => this._serverStateChange(s), e => this._serverHandleError(e))
-    ).catch((error) => {
+    } catch (error) {
       if ( this._options.debugging )
         console.error("Observing server state could not be started: ", error);
 
       this._handleNoSuccess('fail', error);
-    });
+    }
   }
 
   _serverCloseSession() {
@@ -104,69 +95,119 @@ module.exports = class IrmaStateClient {
   }
 
   _serverStateChange(newState) {
-    switch(newState) {
-      case 'PAIRING':
-        if (this._stateMachine.isValidTransition('appPairing'))
-          this._stateMachine.transition('appPairing', this._frontendOptions);
-        return;
-      case 'CONNECTED':
-        if (this._stateMachine.isValidTransition('appConnected'))
-          this._stateMachine.transition('appConnected');
-        return;
-      case 'DONE':
-        // What we hope will happen ;)
-        this._statusListener.close();
-        // We sometimes miss the appConnected transition
-        // on iOS, that's why sometimes we have to do this one first.
-        if (this._stateMachine.isValidTransition('appConnected'))
-          this._stateMachine.transition('appConnected');
-        return this._stateMachine.transition('prepareResult');
-      case 'CANCELLED':
-        // This is a conscious choice by a user.
-        this._statusListener.close();
-        return this._handleNoSuccess('cancel');
-      case 'TIMEOUT':
-        // This is a known and understood error. We can be explicit to the user.
-        this._statusListener.close();
-        return this._handleNoSuccess('timeout');
-      default:
-        // Catch unknown errors and give generic error message. We never really
-        // want to get here.
-        if ( this._options.debugging )
-          console.error('Unknown state received from server:', newState);
+    return this._stateMachine.selectTransition(({validTransitions}) => {
+      switch(newState) {
+        case 'PAIRING':
+          if (validTransitions.includes('appPairing'))
+            return { transition: 'appPairing', payload: this._frontendOptions };
+          break;
+        case 'CONNECTED':
+          if (validTransitions.includes('appConnected'))
+              return { transition: 'appConnected' };
+          break;
+        case 'DONE':
+          // What we hope will happen ;)
+          this._statusListener.close();
+          // We sometimes miss the appConnected transition
+          // on iOS, that's why sometimes we have to do this one first.
+          if (validTransitions.includes('appConnected')) {
+            return { transition: 'appConnected' };
+          } else if (validTransitions.includes('prepareResult')) {
+            return { transition: 'prepareResult' };
+          }
+          break;
+        case 'CANCELLED':
+          // This is a conscious choice by a user.
+          this._statusListener.close();
+          return this._noSuccessTransition(validTransitions, 'cancel');
+        case 'TIMEOUT':
+          // This is a known and understood error. We can be explicit to the user.
+          this._statusListener.close();
+          return this._noSuccessTransition(validTransitions, 'timeout');
+        default:
+          // Catch unknown errors and give generic error message. We never really
+          // want to get here.
+          if ( this._options.debugging )
+            console.error('Unknown state received from server:', newState);
 
-        this._statusListener.close();
-        return this._handleNoSuccess('fail', new Error('Unknown state received from server'));
-    }
+          this._statusListener.close();
+          return this._noSuccessTransition(validTransitions, 'fail', new Error('Unknown state received from server'));
+      }
+      return false;
+    }).then(r => {
+      // In case we postponed the prepareResult transition above, we have to schedule it here.
+      if (r.transition === 'appConnected' && newState == 'DONE') {
+        return this._stateMachine.selectTransition(
+            ({validTransitions}) => validTransitions.includes('prepareResult') ? { transition: 'prepareResult' } : false
+        );
+      }
+    });
   }
 
   _handleNoSuccess(transition, payload) {
-    if (this._canRestart)
-      return this._stateMachine.transition(transition, payload);
-    this._stateMachine.finalTransition(transition, payload);
+    return this._stateMachine.selectTransition(({validTransitions}) =>
+      this._noSuccessTransition(validTransitions, transition, payload)
+    );
   }
 
-  _updatePairingState(continueOnSecondDevice) {
-    if (!this._options.state.pairing)
-      return Promise.resolve();
-
-    // onlyEnableIf may return 'undefined', so we force conversion to boolean by doing a double negation (!!).
-    let shouldBeEnabled = continueOnSecondDevice && !!this._options.state.pairing.onlyEnableIf(this._mappings);
-
-    // Skip the request when the pairing method is correctly set already.
-    if (shouldBeEnabled === this._pairingEnabled) return Promise.resolve();
-
-    if (!this._mappings.frontendAuth) {
-      console.warn('Pairing cannot be enabled, because no frontendAuth token is provided. This might be a security risk.')
-      return Promise.resolve();
+  _noSuccessTransition(validTransitions, transition, payload) {
+    if (validTransitions.includes(transition)) {
+      return {
+        transition: transition,
+        payload: payload,
+        isFinal: !this._canRestart,
+      };
     }
-    this._pairingEnabled = shouldBeEnabled;
 
-    // If pairing should be enabled, parse the pairing options struct.
-    let options = shouldBeEnabled
-      ? { pairingMethod: this._options.state.pairing.pairingMethod }
-      : { pairingMethod: 'none' };
-    return this._updateFrontendOptions(options)
+    // If we cannot handle it in a nice way, we only print it for debug purposes.
+    if (this._options.debugging) {
+      let payloadError = payload ? `with payload ${payload}` : '';
+      console.error(`Unknown transition, tried transition ${transition}`, payloadError);
+    }
+    return false;
+  }
+
+  _updatePairingState(prevTransition, continueOnSecondDevice) {
+    return Promise.resolve()
+      .then(() => {
+        if (!this._options.state.pairing) return;
+
+        // onlyEnableIf may return 'undefined', so we force conversion to boolean by doing a double negation (!!).
+        let shouldBeEnabled = continueOnSecondDevice && !!this._options.state.pairing.onlyEnableIf(this._mappings);
+
+        // Skip the request when the pairing method is correctly set already.
+        if (shouldBeEnabled === this._pairingEnabled) return;
+
+        if (!this._mappings.frontendAuth) {
+          console.warn('Pairing cannot be enabled, because no frontendAuth token is provided. This might be a security risk.')
+          return;
+        }
+        this._pairingEnabled = shouldBeEnabled;
+
+        // If pairing should be enabled, parse the pairing options struct.
+        let options = shouldBeEnabled
+            ? {pairingMethod: this._options.state.pairing.pairingMethod}
+            : {pairingMethod: 'none'};
+        return this._updateFrontendOptions(options)
+      })
+      .then(() => this._stateMachine.selectTransition(({validTransitions}) => {
+        if (continueOnSecondDevice) {
+          return validTransitions.includes('showQRCode') ? {
+            transition: 'showQRCode',
+            payload: {
+              qr: JSON.stringify(this._mappings.sessionPtr),
+              showBackButton: prevTransition == 'chooseQR',
+            }
+          } : false;
+        } else {
+          return validTransitions.includes('showIrmaButton') ? {
+            transition: 'showIrmaButton',
+            payload: {
+              mobile: this._getMobileUrl(this._mappings.sessionPtr),
+            }
+          } : false;
+        }
+      }))
       .catch(err => {
         if ( this._options.debugging )
           console.error('Error received while updating pairing state:', err);
@@ -227,19 +268,19 @@ module.exports = class IrmaStateClient {
 
   _determineFlow() {
     this._userAgent = userAgent();
-    // A new transition cannot be started within stateChange, so add call to javascript event loop.
-    Promise.resolve().then(() => {
+    return this._stateMachine.selectTransition(({validTransitions}) => {
       switch (this._userAgent) {
         case 'Android':
         case 'iOS':
-          if (this._stateMachine.isValidTransition('prepareButton'))
-            this._stateMachine.transition('prepareButton');
+          if (validTransitions.includes('prepareButton'))
+            return { transition: 'prepareButton' };
           break;
         default:
-          if (this._stateMachine.isValidTransition('prepareQRCode'))
-            this._stateMachine.transition('prepareQRCode');
+          if (validTransitions.includes('prepareQRCode'))
+            return { transition: 'prepareQRCode' };
           break;
       }
+      return false;
     });
   }
 

--- a/plugins/irma-console/irma-console.js
+++ b/plugins/irma-console/irma-console.js
@@ -36,8 +36,8 @@ module.exports = (askRetry, askPairingCode) => {
     }
 
     _askPairingCode(askedBefore) {
-      return this._stateMachine.selectTransition(({validTransitions, isEndState}) => {
-        if (isEndState) return false;
+      return this._stateMachine.selectTransition(({validTransitions, inEndState}) => {
+        if (inEndState) return false;
         if (askedBefore && !askRetry("Wrong pairing code was entered.")) {
           let transition = validTransitions.includes('cancel') ? 'cancel' : 'abort';
           return { transition };
@@ -50,8 +50,8 @@ module.exports = (askRetry, askPairingCode) => {
     }
 
     _askRetry(message) {
-      return this._stateMachine.selectTransition(({validTransitions, isEndState}) => {
-        if (isEndState) return false;
+      return this._stateMachine.selectTransition(({validTransitions, inEndState}) => {
+        if (inEndState) return false;
         let transition = validTransitions.includes('restart') && askRetry(message)
           ? 'restart'
           : 'abort';

--- a/plugins/irma-popup/index.js
+++ b/plugins/irma-popup/index.js
@@ -9,8 +9,8 @@ module.exports = class IrmaPopup {
     this._options = this._sanitizeOptions(options);
 
     this._dom = new DOMManipulations(options.element, () =>
-      this._stateMachine.selectTransition(({isEndState}) => {
-        if (!isEndState) {
+      this._stateMachine.selectTransition(({inEndState}) => {
+        if (!inEndState) {
           return { transition: 'abort' };
         } else if (this._popupClosedEarly) {
           this._popupClosedEarly();

--- a/plugins/irma-popup/index.js
+++ b/plugins/irma-popup/index.js
@@ -8,13 +8,15 @@ module.exports = class IrmaPopup {
     this._stateMachine = stateMachine;
     this._options = this._sanitizeOptions(options);
 
-    this._dom = new DOMManipulations(options.element, () => {
-      if (!stateMachine.isEndState()) {
-        stateMachine.transition('abort');
-      } else if (this._popupClosedEarly) {
-        this._popupClosedEarly();
-      }
-    });
+    this._dom = new DOMManipulations(options.element, () =>
+      this._stateMachine.selectTransition(({isEndState}) => {
+        if (!isEndState) {
+          return { transition: 'abort' };
+        } else if (this._popupClosedEarly) {
+          this._popupClosedEarly();
+        }
+      })
+    );
 
     this._irmaWeb = new IrmaWeb({
       stateMachine,

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -11,12 +11,11 @@ module.exports = class IrmaWeb {
     this._dom = new DOMManipulations(
       document.querySelector(this._options.element),
       this._options,
-      (t) => this._stateMachine.selectTransition(({validTransitions}) => {
-        // Check for validity of function to prevent errors when multiple events are cached.
-        if (validTransitions.includes(t))
-          return {transition: t, payload: this._lastPayload};
-        return false;
-      }),
+      (t) => this._stateMachine.selectTransition(({validTransitions}) =>
+        validTransitions.includes(t)
+          ? { transition: t, payload: this._lastPayload }
+          : false
+      ),
       (enteredPairingCode) => this._stateMachine.selectTransition(({validTransitions}) =>
         validTransitions.includes('codeEntered')
           ? { transition: 'codeEntered', payload: {enteredPairingCode} }

--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -11,12 +11,17 @@ module.exports = class IrmaWeb {
     this._dom = new DOMManipulations(
       document.querySelector(this._options.element),
       this._options,
-      (t) => {
+      (t) => this._stateMachine.selectTransition(({validTransitions}) => {
         // Check for validity of function to prevent errors when multiple events are cached.
-        if (this._stateMachine.isValidTransition(t))
-          this._stateMachine.transition(t, this._lastPayload);
-      },
-      (enteredPairingCode) => this._stateMachine.transition('codeEntered', {enteredPairingCode})
+        if (validTransitions.includes(t))
+          return {transition: t, payload: this._lastPayload};
+        return false;
+      }),
+      (enteredPairingCode) => this._stateMachine.selectTransition(({validTransitions}) =>
+        validTransitions.includes('codeEntered')
+          ? { transition: 'codeEntered', payload: {enteredPairingCode} }
+          : false
+      )
     );
 
     this._addVisibilityListener();
@@ -53,24 +58,27 @@ module.exports = class IrmaWeb {
   }
 
   _addVisibilityListener() {
-    const onVisibilityChange = () => {
-      if (this._stateMachine.currentState() != 'TimedOut' || document.hidden) return;
-      if (this._stateMachine.isValidTransition('restart')) {
-        if (this._options.debugging) console.log('🖥 Restarting because document became visible');
-        this._stateMachine.transition('restart');
-      }
-    };
-    const onFocusChange = () => {
-      if ( this._stateMachine.currentState() != 'TimedOut' ) return;
-      if (this._stateMachine.isValidTransition('restart')) {
-        if ( this._options.debugging ) console.log('🖥 Restarting because window regained focus');
-        this._stateMachine.transition('restart');
-      }
-    };
-    const onResize = () => {
-      if (this._stateMachine.isValidTransition('checkUserAgent'))
-        this._stateMachine.transition('checkUserAgent', this._lastPayload);
-    };
+    const onVisibilityChange = () => this._stateMachine.selectTransition(({state, validTransitions}) => {
+      if (state != 'TimedOut' || document.hidden || !validTransitions.includes('restart'))
+        return false;
+
+      if (this._options.debugging) console.log('🖥 Restarting because document became visible');
+      return {transition: 'restart'};
+    });
+
+    const onFocusChange = () => this._stateMachine.selectTransition(({state, validTransitions}) => {
+      if (state != 'TimedOut' && !validTransitions.includes('restart'))
+        return false;
+
+      if ( this._options.debugging ) console.log('🖥 Restarting because window regained focus');
+      return {transition: 'restart'};
+    });
+
+    const onResize = () => this._stateMachine.selectTransition(({validTransitions}) => {
+      if (validTransitions.includes('checkUserAgent'))
+        return {transition: 'checkUserAgent', payload: this._lastPayload};
+      return false;
+    });
 
     if ( typeof document !== 'undefined' && document.addEventListener )
       document.addEventListener('visibilitychange', onVisibilityChange);


### PR DESCRIPTION
We want to get rid of the possibility for developers of plugins (like we are ourselves, but also devs that make custom plugins) to introduce race conditions. This change is based on the discussions in PR #35 .

## Problem
The `transition` function used to be blocking. This causes problems when you call `transition` from within `stateChange` of one of the plugins. This is a quite logical thing to do in some situations, for example when you have to deal with an error. Lets assume we have plugin `a` and `b` begin registered at the state machine and we are in a state change for transition `x` and plugin `a` wants to throw an error:

**Stack trace from the perspective of plugin `a`:**

 * stateChange transition `x`
   * Plugin A initiates transition `fail`
     * stateChange transition `fail`
   * Continue processing state change transition `x`

Here you have the weird behaviour that processing of the old state change continues after the new state has already been processed. This means that plugin `a` is processing a state change of a state in the past.

**Stack trace from the perspective of plugin `b`:**
From the perspective of plugin `b` it is even more weird:
 * stateChange transition `fail`
 * stateChange transition `x`

Here the state change is fully executed in the wrong order. Developers might not be aware that state changes can come in in any order, so this makes it very hard to reason about it. Practically, you have to support the state change from `x` to `y` for every possible state `x` and `y`. This makes no sense.

## Proposed change
I made the transition function async, without using promise chaining. This means that transitions are added to the JavaScript event loop, making sure state changes are executed in the right order. I explicitly don't use promise chaining. When allowing promise chaining, the state change might get scattered over multiple events in the event loop, making it again possible that state changes get mixed up.

Making it async, makes it harder to reason about a state change when you want to do it conditionally. For example, if you check that transition `x` is possible now and you initiate the transition, you are not sure that transition `x` is still valid when it is actually performed. A transition of another plugin might have intervened.

Therefore I deprecate the `getState`, `isEndState` and `isValidTransition` methods and replace them by a `selectTransition` method that makes it possible to do the validity check on the exact moment the transition is scheduled. This prevents any race condition to happen.
