### PR TITLE
Fix: HTTP error responses from result endpoint go unnoticed

### DIFF
--- a/plugins/irma-client/session-client.js
+++ b/plugins/irma-client/session-client.js
@@ -66,6 +66,13 @@ module.exports = class IrmaSessionClient {
           this._stateMachine.selectTransition(({ validTransitions }) =>
             validTransitions.includes('succeed') ? { transition: 'succeed', payload: result } : false
           )
+        )
+        .catch((error) =>
+          this._stateMachine.selectTransition(({ validTransitions }) => {
+            if (this._options.debugging) console.error('Error getting result from the server:', error);
+            if (validTransitions.includes('fail')) return { transition: 'fail', payload: error };
+            throw error;
+          })
         );
     }
   }


### PR DESCRIPTION
**Solution for a bug:**

While updating my home server I found an issue with irma-frontend. When logging in on https://metrics.drksn.nl with any other combination of attributes than the allowed one (which is only mine at the moment), the `result` endpoint will throw an error that the user is forbidden to continue. Instead of an error being visible, irma-frontend gets stuck in a loading state forever.

The solution is quite trivial, so instead of reporting an issue, I immediately made a pull request proposing the solution.