### PR TITLE
Static require statements for translations

### DIFF
--- a/plugins/irma-web/index.js
+++ b/plugins/irma-web/index.js
@@ -1,5 +1,9 @@
 const DOMManipulations = require('./dom-manipulations');
 const merge = require('deepmerge');
+const translations = {
+  nl: require('./translations/nl'),
+  en: require('./translations/en'),
+};
 
 module.exports = class IrmaWeb {
   constructor({ stateMachine, options }) {
@@ -50,7 +54,7 @@ module.exports = class IrmaWeb {
       element: '#irma-web-form',
       showHelper: false,
       fallbackDelay: 1000,
-      translations: require(`./translations/${options.language || 'nl'}`),
+      translations: translations[options.language || 'nl'],
     };
 
     return merge(defaults, options);


### PR DESCRIPTION
Various bundlers do not support require statements at runtime/with variables. Since there are only a few translations the impact of statically requiring all translations on the total bundle size is negligible.